### PR TITLE
Raise IntervalArithmetic bounds to v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "IntervalBoxes"
 uuid = "43d83c95-ebbb-40ec-8188-24586a1458ed"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-IntervalArithmetic = "^0.22.12"
+IntervalArithmetic = "0.22.12 - 1"
 StaticArrays = "1"
 julia = "1.9"

--- a/test/display.jl
+++ b/test/display.jl
@@ -13,7 +13,7 @@ using Test
     @test s == "[1.0, 2.0] × [3.0, 4.0]"
 
     X = bareinterval.(IntervalBox(1.1..1.2, 2.1..2.2))
-    @test string(X) == "[1.09999, 1.20001] × [2.09999, 2.20001]"
+    @test string(X) == "[1.1, 1.2] × [2.1, 2.2]"
 
     X = bareinterval.(IntervalBox(-Inf..Inf, -Inf..Inf))
     @test string(X) == "(-∞, ∞)²"


### PR DESCRIPTION
I added a new release version here (v0.2.3) but now realized that v0.2.2 has not been released yet. I suggest to do that first.